### PR TITLE
Don't specify addrProtocol to work with Unix sockets

### DIFF
--- a/src/Database/PostgreSQL/Pure/Internal/Connection.hs
+++ b/src/Database/PostgreSQL/Pure/Internal/Connection.hs
@@ -81,7 +81,6 @@ addrInfoHints :: NS.AddrInfo
 addrInfoHints =
   NS.defaultHints
     { NS.addrSocketType = NS.Stream
-    , NS.addrProtocol = 6 -- TCP
     , NS.addrFlags = [NS.AI_ADDRCONFIG]
     }
 


### PR DESCRIPTION
Simply removing this seems to work for both TCP and Unix sockets, but I've only tested on Linux.